### PR TITLE
switching to ghcjs-0.2.0.20151029_ghc-7.10.2; fixes compile problems

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -31,13 +31,13 @@ extra-package-dbs: []
 # extra-include-dirs: [/path/to/dir]
 # extra-lib-dirs: [/path/to/dir]
 
-compiler: ghcjs-0.2.0.20151001_ghc-7.10.2
+compiler: ghcjs-0.2.0.20151029_ghc-7.10.2
 compiler-check: match-exact
 setup-info:
   ghcjs:
     source:
-      ghcjs-0.2.0.20151001_ghc-7.10.2:
-        url: "https://github.com/fizruk/ghcjs/releases/download/v0.2.0.20151001/ghcjs-0.2.0.20151001.tar.gz"
+      ghcjs-0.2.0.20151029_ghc-7.10.2:
+        url: "https://github.com/nrolland/ghcjs/releases/download/v0.2.0.20151029/ghcjs-0.2.0.20151029.tar.gz"
 
 # extra-depends:
 # - sta


### PR DESCRIPTION
I believe this change will take care of the compile problems you were seeing the other day.  The change is just to move up to the latest version of ghcjs mentioned in the haskellstack.org ghcjs documentation:

http://docs.haskellstack.org/en/stable/ghcjs.html

If it works for you would you please update the stackoverflow comments accordingly 

http://stackoverflow.com/questions/29967135/how-to-call-haskell-from-javascript-with-ghcjs
